### PR TITLE
Add IELTS Writing Practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Please help me revise and modify the following prompt for better clarity and pre
 #### Language Learning
 | Name | Cost | Description |
 | --- | --- | --- |
+| [IELTS Writing Practice](https://ieltswritingpractice.app/) | Free question bank and timed drafting; account and paid plan required for AI feedback. | Practise IELTS Academic Task 1, General Training Task 1, and Task 2, then get estimated band scores and criterion-specific feedback. |
 | [IELTS Speaking - English & Language Learning](https://chatgpt.com/g/g-LDICowG2o-ielts-speaking-english-language-learning) | Available for free users with limited access; account required. \<GPTs\> | IELTS Speaking Test, providing scores. You can use voice mode to start. It has the latest IELTS topics. |
 | [IELTS AI Checker (Speaking and Writing) Official®](https://chatgpt.com/g/g-YScypAShQ-ielts-ai-checker-speaking-and-writing-official-r)| Available for free users with limited access; account required. \<GPTs\> | AI IELTS speaking and writing tool - band score with feedback. |
 | [Language Teacher \| Ms. Smith](https://chatgpt.com/g/g-RR3RCyK8N-language-teacher-ms-smith)| Available for free users with limited access; account required. \<GPTs\> |Supports 20+ languages - Spanish, German, French, English, Chinese, Korean, Japanese, ... Your private tutor to learn any language in most effective way by having conversation. Increase your vocabulary by talking about fun topics, coach you. |


### PR DESCRIPTION
Adds [IELTS Writing Practice](https://ieltswritingpractice.app/) to Language Learning. It combines a public IELTS question bank with timed drafting for Academic Task 1, General Training Task 1, and Task 2, plus optional AI feedback.

The public question bank and timed drafting are free. Submitting writing for AI score estimates and detailed corrections requires an account and paid plan.

Disclosure: I maintain IELTS Writing Practice and IELTS Writing Checker (ieltswritingchecker.org). This entry focuses on IELTS Writing Practice's question bank and timed drafting workflow; existing entries are preserved.

Validation: inspected the live homepage and pricing in Chrome, checked the proposed URL and name against the current repository, and ran `git diff --check`.
